### PR TITLE
Fixes the build config to exclude the open graph image from asset hashing

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -67,7 +67,7 @@ configure :build do
   activate :cache_buster
 
   # Enable asset pipeline
-  activate :asset_hash, ignore: ['favicon.png', /downloads\/*/]
+  activate :asset_hash, ignore: ['favicon.png', '/images/og-standard.jpg', /downloads\/*/]
 
   # Use relative URLs
   activate :relative_assets


### PR DESCRIPTION
Otherwise the og-standard.jpg has an asset hash and is not available to platforms using the open graph standard.
