### PR TITLE
Updated Downloads Description

### DIFF
--- a/source/sections/_download.haml
+++ b/source/sections/_download.haml
@@ -37,7 +37,7 @@
       %ul.g
         %li= link_to 'backbone.marionette.js', 'downloads/core/backbone.marionette.js'
         %li= link_to 'backbone.marionette.min.js', 'downloads/core/backbone.marionette.min.js'
-    %h3 AMD / RequireJS
+    %h3 AMD / CommonJS
     .gw
       %ul.g
         %li= link_to 'backbone.marionette.js', 'downloads/core/amd/backbone.marionette.js'


### PR DESCRIPTION
Right now the title for the second download on the Marionette page says `AMD/RequireJS`. Since RequireJS uses AMD, it may be considered superfluous to include that in the title as well. Either way, a slightly bigger concern is that download also seems to support CommonJS-like environments, like Node, but there's no information about that on the page.

This may have led to issues like [this one](https://github.com/marionettejs/backbone.marionette/issues/880) where a user was unable to determine how to load Marionette in a CommonJS-like environment (I _think_ Components is CommonJS-like, as Node is, but do correct me if you know otherwise).

This PR replaces 'RequireJS' with 'CommonJS' in the title, but there are some nuances to consider. Firstly, according to [this UMD pattern](https://github.com/umdjs/umd/blob/master/returnExports.js) it doesn't seem to support stricter CommonJS environments. Calling it `CommonJS` may confuse users in those stricter environments.

Something else to consider is that the second download also works as a browser global. I'm sure it was intentionally split up, but maybe it'd be easier to just have a single download? That is how Backbone works, so I don't think it'd be too confusing to most users. The cost is a slightly larger file, but the size might be considered negligible compared to the total size of the combination of jquery, underscore, backbone, and marionette.
