### PR TITLE
new deploy task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec middleman build && rackup config.ru -p $PORT
+web: bundle exec rackup config.ru -p $PORT

--- a/Rakefile
+++ b/Rakefile
@@ -9,13 +9,8 @@ require "fileutils"
 def git_initialize(repository)
   unless File.exist?(".git")
     system "git init"
-    system "git remote add origin git@github.com:marionettejs/#{repository}.git"
+    system "git remote add heroku git@heroku.com:#{repository}.git"
   end
-end
-
-def git_update
-  system "git fetch origin"
-  system "git reset --hard origin/master"
 end
 
 def marionette_path
@@ -113,28 +108,24 @@ task :backfill_anotated_source do
 end
 
 desc "Build and deploy the website to github pages"
-task :deploy => :docco do |t, args|
+task :deploy do
   require "highline/import"
   message = "Deploy marionettejs.com"
 
   mkdir_p "build"
 
   Dir.chdir "build" do
-    git_initialize("marionettejs.github.com")
-    git_update
+    git_initialize("marionette-www")
   end
 
   build
 
   Dir.chdir "build" do
+    system "cp ../config.ru ."
+    system "cp ../Procfile ."
     system "git add -A"
     system "git commit -m '#{message.gsub("'", "\\'")}'"
-    system "git push origin master"
+    system "git push --force heroku master"
   end
 
-end
-
-desc "Build annotated source code"
-task :docco do
-  `./build-docco`
 end

--- a/config.ru
+++ b/config.ru
@@ -8,7 +8,6 @@ end
 
 # Serve files from the build directory
 use Rack::TryStatic,
-  root: 'build',
   urls: %w[/],
   try: ['.html', 'index.html', '/index.html']
 


### PR DESCRIPTION
Amended `rake deploy` task to push build folder to heroku. This means mean the only command heroku needs to make is to start the server.
