### PR TITLE
Fix <select> cutting text top and bottom (see screenshots)

### DIFF
--- a/source/doc-assets/css/main.css
+++ b/source/doc-assets/css/main.css
@@ -57,6 +57,11 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
   margin-bottom: 10px;
 }
 
+select.form-control {
+    padding-top: 0;
+    padding-bottom: 0;
+}
+
 pre table {
     border-spacing: 0;
 }


### PR DESCRIPTION
OS: Windows 7
Firefox
![firefox](https://cloud.githubusercontent.com/assets/963212/3973337/ccb71e28-27e6-11e4-9b6d-7f1725a0e96d.png)

Chrome
![chrome](https://cloud.githubusercontent.com/assets/963212/3973338/cefaccf2-27e6-11e4-81c8-a8b1462b59f0.png)

After Fix

Firefox
![firefox_fix](https://cloud.githubusercontent.com/assets/963212/3973667/76e00736-27ea-11e4-9c56-3d0186c4e966.png)

Chrome
![chrome_fix](https://cloud.githubusercontent.com/assets/963212/3973676/82508884-27ea-11e4-8f71-97f526cd2a6c.png)
