### PR TITLE
First pass for www api support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@
 # Ignore the build directory
 /build
 
-# Ignore the docs source
+# Ignore the api & docs source
 /source/docs
+/source/api
 
 # Ignore the annotated source
 /source/annotated-src
@@ -26,3 +27,6 @@ source/stylesheets/.git
 .DS_Store
 *.zip
 node_modules
+
+# Ignore api files
+source/api-assets/jsDocFile.json

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "marionette-www",
   "dependencies": {
     "mdoc": "git://github.com/ahumphreys87/mdoc.git#v0.4.0",
-    "docco": "~0.6.3"
+    "docco": "~0.6.3",
+    "handlebars": "~2.0.0",
+    "underscore": "1.4.4 - 1.7.0"
   }
 }

--- a/source/api-assets/build.js
+++ b/source/api-assets/build.js
@@ -1,0 +1,36 @@
+var Handlebars = require('handlebars');
+var fs = require('fs');
+var _ = require('underscore');
+
+
+console.log('Starting jsDocFile build...\n');
+
+var doc = fs.readFileSync("jsDocFile.json").toString();
+var json = JSON.parse(doc);
+
+
+
+// WRITE index file
+//
+var indexHbs = fs.readFileSync("index.hbs").toString();
+var index = Handlebars.compile(indexHbs)(json);
+
+fs.writeFile('../api/index.html', index, function(err) {
+  if (err) {
+    console.log('error', err);
+  }
+})
+
+// WRITE class files
+var classHbs = fs.readFileSync("class.hbs").toString();
+var classTpl = Handlebars.compile(classHbs)
+
+_.each(json.classes, function(klass) {
+  var classHtml = classTpl(klass);
+
+  fs.writeFile('../api/'+klass.name+'.html', classHtml, function(err) {
+    if (err) {
+      console.log('error', err);
+    }
+  })
+})

--- a/source/api-assets/class.hbs
+++ b/source/api-assets/class.hbs
@@ -1,0 +1,42 @@
+<h1>{{name}}</h1>
+<p>{{class}}</p>
+
+{{{description}}}
+
+<h2>Examples</h2>
+{{#each examples}}
+  <h3>{{name}}</h3>
+  <div>
+    {{{example}}}
+  </div>
+{{/each}}
+
+<h2>Functions</h2>
+{{#with constructor}}
+  <h3>Constructor</h3>
+  {{#with description}}
+    {{#params}}
+      <div>{{name}} - {{type}} - {{description}}</div>
+    {{/params}}
+  {{/with}}
+{{/with}}
+
+{{#each functions}}
+  <h3>{{@key}}</h3>
+  {{#with description}}
+    {{{description.full}}}
+
+    <h4>Params</h4>
+    {{#params}}
+      <div>{{name}} - {{type}} - {{description}}</div>
+    {{/params}}
+  {{/with}}
+
+  {{#if examples}}
+    <h4>Examples</h4>
+    {{#each examples}}
+      <h4>{{name}}</h4>
+      {{{example}}}
+    {{/each}}
+  {{/if}}
+{{/each}}

--- a/source/api-assets/index.hbs
+++ b/source/api-assets/index.hbs
@@ -1,0 +1,24 @@
+<h1>Marionette Api</h1>
+
+<div class="sidebar">
+  <h3>Classes</h3>
+  <ul>
+    {{#classes}}
+      <li>{{name}}</li>
+    {{/classes}}
+  </ul>
+
+  <h3>Functions</h3>
+  <ul>
+    {{#each functions}}
+      <li>{{@key}}</li>
+    {{/each}}
+  </ul>
+
+  <h3>Properties</h3>
+  <ul>
+    {{#each properties}}
+      <li>{{@key}}</li>
+    {{/each}}
+  </ul>
+</div>


### PR DESCRIPTION
This is a work in progress. Just sharing the PR to track the work... This will probably be done next week at the hackathon. 

---

The api task currently compiles the jsdoc and reads it into a ruby hash of properties, functions, and classes.

The next step is to create templates for:
- sidebar
- Marionette namespace w/ functions, properties, classes
- Marionette class

---

Sidenote: The work is split between a rake task and a build step. This division of labor is a little arbitrary and somewhat intentional. 

The thinking went like this, the js build will take a full api json file and build the templates. 

The rake/ruby will generate the json by running shell commands in `marionette` repo. 

I did this to keep the api rake task comparable to the docs task, which follows a similar pattern of doing the compilation in ruby and the templating in js. Down the road, @thejameskyle work will probably port the ruby stuff to node...

---

Down the road, the build phase would have to loop over tags of marionette that support jsdoc - but for now we'll just grab the most recent. 

<!---
@huboard:{"order":122.0,"milestone_order":122,"custom_state":""}
-->
